### PR TITLE
Create Universal_drivers.md

### DIFF
--- a/Universal_drivers.md
+++ b/Universal_drivers.md
@@ -1,0 +1,164 @@
+> Okay, I need to write keyboard drivers for four different operating systems: Android, Mac, Linux, and Windows. Each in different languages—C for Android and Linux, Objective-C for Mac, and C++ for Windows. Let me start by breaking down what each entails.
+  For Android, a keyboard driver would interact at the kernel level. I remember that Linux kernel modules are written in C, so Android being based on Linux, the driver would be a kernel module. The basic structure involves module initialization, registering an input device, and handling interrupts or input events. I'll need to create an input device, set up key bits, and then simulate key presses. But wait, Android might have specific requirements or interfaces. Maybe using the Input Subsystem, similar to standard Linux drivers. So, the code would involve module_init, input_register_device, and generating events with input_report_key and input_sync.
+  Moving to Mac (macOS), the user mentioned Objective-C. But macOS kernel extensions (kexts) are usually written in C, not Objective-C. Maybe there's a confusion here. Objective-C is for user-space applications. For a kernel driver, it's more likely C. However, since the user specified Objective-C for Mac, perhaps they want a user-space component? Or maybe a misunderstanding. I'll need to clarify, but given the instruction, I'll proceed with Objective-C. Wait, but kernel programming in Objective-C is unusual. Maybe they meant a user-level event tap or something using IOKit framework, which is in C. Hmm. This part might be tricky. IOKit drivers are in C++, but the user says Objective-C. Maybe a Cocoa application that intercepts keyboard events? Like using NSEvent addGlobalMonitorForEventsMatchingMask. But that's for applications, not drivers. The user might have mixed up kernel vs user space. For a kernel driver, I'll have to use C or C++ with IOKit. But since the user insists on Objective-C for Mac, perhaps a mistake. I'll proceed with a hypothetical Objective-C driver, but note the discrepancy.
+  For Linux, again a kernel module in C. Similar to Android, since Android is based on Linux. The code would involve registering an input device, handling interrupts (maybe from a hardware port), and sending events. The structure would be like writing a basic char driver or input subsystem driver. But handling actual hardware might require access to ports or using APIs like request_irq for interrupts. Since we're simulating, maybe a simple module that creates a device file and allows writing key events to it.
+  For Windows, the user wants C++. Windows drivers are typically written using the Windows Driver Framework (WDF) or the older WDM. The code would involve creating a KMDF (Kernel-Mode Driver Framework) driver. The driver would handle IRPs (I/O Request Packets), create a device object, and interact with the HID (Human Interface Device) class. The driver would need to handle IOCTLs or read/write requests to pass key events. In C++, the code would set up a driver entry, device initialization, and maybe a queue for handling reads. But implementing a full HID driver is complex. Maybe a simpler example that creates a device and allows user-mode communication.
+  Wait, but each of these examples would be very basic, as writing full drivers is complex. The user might be looking for skeleton code that outlines the structure. Also, handling actual hardware access is OS and hardware-specific. For example, in Linux, inb/outb for port access, but these are x86-specific and might require permissions. Alternatively, using a virtual device or uinput for Linux/Android.
+  Let me outline each:
+  Android (C): Since Android uses the Linux kernel, the driver would be a kernel module using the input subsystem. Using functions like input_allocate_device, input_register_device, and then sending events with input_report_key, input_sync. The module would need to handle initialization and cleanup.
+  Mac (Objective-C): This is confusing. Maybe a user-space daemon using IOKit in C. Alternatively, using a Cocoa app with event taps. For example, using NSEvent masks to monitor global events. But that's not a driver. If the user insists on Objective-C, perhaps a command-line tool using IOKit framework, but IOKit is C-based. Maybe mix Objective-C and C. But this is getting complicated. Perhaps a basic IOKit driver in C, but the user asked for Objective-C. Maybe a mistake, but proceed with a note.
+  Linux (C): Similar to Android, a kernel module using input subsystem. Register an input device, send key events. Maybe using a timer to simulate periodic key presses or handling interrupts.
+  Windows (C++): Using WDF to create a KMDF driver. Implement driver entry, device creation, and a queue for handling IO requests. The driver could expose a device that user-mode apps can communicate with to send key events.
+  But all of these are very simplified. Real drivers handle hardware specifics, which vary widely. Also, installing kernel drivers requires signing and administrative privileges, which is beyond the code.
+  Now, considering the example code:
+  For Android/Linux: The code would look similar. Maybe in Android's case, using uinput (user-level input) if in userspace, but as a kernel driver, it's similar to Linux. The example provided in the answer uses a kernel module with input_allocate_device etc.
+  Mac: If using a kext, which is deprecated in macOS now, but for the sake of example, a simple IOKit driver in C. But the user asked for Objective-C. Maybe they want a user-space program? Using IOKit in Objective-C? For example, finding HID devices and interacting with them. But that's not a driver. This part is unclear.
+  Windows: WDF driver in C++. The code would have DRIVER_INITIALIZE DriverEntry, create a device, set up IO queues. Then handle read/write requests to simulate input. But to actually inject keystrokes, the driver would need to interact with the HID stack, which is more involved.
+  So, the answer would provide skeleton code for each, noting that they are simplified and that real drivers require more handling, hardware specifics, and proper setup.
+  Potential issues to note: Deprecated frameworks (like kexts in macOS), the complexity of driver signing, administrative access, and hardware differences. Also, security implications of writing kernel drivers.
+  Need to include warnings that this is simplified and not production-ready, and that driver development requires in-depth knowledge of the OS and hardware.
+  Creating keyboard drivers for different operating systems involves low-level programming and interaction with hardware or system frameworks. Below are simplified examples for each platform. Note that these are basic templates and not production-ready solutions. Real drivers require handling hardware specifics, security, and system integration.
+
+---
+
+### 1. **Android (C) – Linux Kernel Input Subsystem**
+Android uses the Linux kernel, so a keyboard driver can be a kernel module using the input subsystem.
+
+```c
+#include <linux/module.h>
+#include <linux/input.h>
+#include <linux/init.h>
+
+static struct input_dev *keyboard_dev;
+
+static int __init keyboard_init(void) {
+    // Allocate input device
+    keyboard_dev = input_allocate_device();
+    if (!keyboard_dev) return -ENOMEM;
+
+    // Set up device properties
+    keyboard_dev->name = "Simple Keyboard";
+    keyboard_dev->evbit[0] = BIT_MASK(EV_KEY);
+    keyboard_dev->keybit[BIT_WORD(KEY_A)] = BIT_MASK(KEY_A);
+
+    // Register the device
+    if (input_register_device(keyboard_dev)) {
+        input_free_device(keyboard_dev);
+        return -ENODEV;
+    }
+
+    // Simulate pressing 'A'
+    input_report_key(keyboard_dev, KEY_A, 1);
+    input_sync(keyboard_dev);
+    return 0;
+}
+
+static void __exit keyboard_exit(void) {
+    input_unregister_device(keyboard_dev);
+    input_free_device(keyboard_dev);
+}
+
+module_init(keyboard_init);
+module_exit(keyboard_exit);
+
+MODULE_LICENSE("GPL");
+```
+
+---
+
+### 2. **macOS (Objective-C) – IOKit HID Driver (C)**
+**Note:** macOS kernel extensions (kexts) are deprecated. Here's a minimal IOKit driver in **C** (Objective-C isn't used in kernel space):
+
+```c
+#include <IOKit/IOLib.h>
+#include <IOKit/IOService.h>
+
+class SimpleKeyboardDriver : public IOService {
+    OSDeclareDefaultStructors(SimpleKeyboardDriver);
+
+public:
+    virtual bool init(OSDictionary *dict) override {
+        if (!IOService::init(dict)) return false;
+        return true;
+    }
+
+    virtual void free() override {
+        IOService::free();
+    }
+};
+
+OSDefineMetaClassAndStructors(SimpleKeyboardDriver, IOService);
+```
+
+**Important:** Modern macOS prefers user-space HID drivers using frameworks like `IOKit` and `CoreFoundation`.
+
+---
+
+### 3. **Linux (C) – Kernel Input Module**
+Similar to Android, but may handle hardware interrupts:
+
+```c
+#include <linux/module.h>
+#include <linux/input.h>
+#include <linux/interrupt.h>
+
+static struct input_dev *linux_keyboard_dev;
+
+static irqreturn_t keyboard_interrupt(int irq, void *dev_id) {
+    input_report_key(linux_keyboard_dev, KEY_SPACE, 1);
+    input_sync(linux_keyboard_dev);
+    return IRQ_HANDLED;
+}
+
+static int __init linux_keyboard_init(void) {
+    linux_keyboard_dev = input_allocate_device();
+    // ... (similar setup to Android example)
+    return 0;
+}
+
+static void __exit linux_keyboard_exit(void) {
+    input_unregister_device(linux_keyboard_dev);
+}
+
+module_init(linux_keyboard_init);
+module_exit(linux_keyboard_exit);
+MODULE_LICENSE("GPL");
+```
+
+---
+
+### 4. **Windows (C++) – WDF KMDF Driver**
+A basic keyboard driver using the Windows Driver Framework:
+
+```cpp
+#include <ntddk.h>
+#include <wdf.h>
+
+DRIVER_INITIALIZE DriverEntry;
+EVT_WDF_DRIVER_DEVICE_ADD SimpleKeyboardEvtDeviceAdd;
+
+NTSTATUS DriverEntry(PDRIVER_OBJECT DriverObject, PUNICODE_STRING RegistryPath) {
+    WDF_DRIVER_CONFIG config;
+    WDF_DRIVER_CONFIG_INIT(&config, SimpleKeyboardEvtDeviceAdd);
+    return WdfDriverCreate(DriverObject, RegistryPath, WDF_NO_OBJECT_ATTRIBUTES, &config, WDF_NO_HANDLE);
+}
+
+NTSTATUS SimpleKeyboardEvtDeviceAdd(WDFDRIVER Driver, PWDFDEVICE_INIT DeviceInit) {
+    WDFDEVICE device;
+    NTSTATUS status = WdfDeviceCreate(&DeviceInit, WDF_NO_OBJECT_ATTRIBUTES, &device);
+    if (!NT_SUCCESS(status)) return status;
+
+    // Set up HID or keyboard-specific functionality here
+    return status;
+}
+```
+
+---
+
+### Key Notes:
+1. **Complexity**: Real drivers handle hardware communication (e.g., USB, PS/2), interrupts, and system security.
+2. **Signing**: Modern OSes require drivers to be signed (e.g., Windows HLK, macOS notarization).
+3. **Deprecations**: macOS kexts are deprecated; use user-space HID drivers instead.
+4. **Testing**: Use virtual machines or test hardware to avoid system instability.
+
+Always refer to official OS documentation for up-to-date practices.


### PR DESCRIPTION
> Okay, I need to write keyboard drivers for four different operating systems: Android, Mac, Linux, and Windows. Each in different languages—C for Android and Linux, Objective-C for Mac, and C++ for Windows. Let me start by breaking down what each entails.
  For Android, a keyboard driver would interact at the kernel level. I remember that Linux kernel modules are written in C, so Android being based on Linux, the driver would be a kernel module. The basic structure involves module initialization, registering an input device, and handling interrupts or input events. I'll need to create an input device, set up key bits, and then simulate key presses. But wait, Android might have specific requirements or interfaces. Maybe using the Input Subsystem, similar to standard Linux drivers. So, the code would involve module_init, input_register_device, and generating events with input_report_key and input_sync.
  Moving to Mac (macOS), the user mentioned Objective-C. But macOS kernel extensions (kexts) are usually written in C, not Objective-C. Maybe there's a confusion here. Objective-C is for user-space applications. For a kernel driver, it's more likely C. However, since the user specified Objective-C for Mac, perhaps they want a user-space component? Or maybe a misunderstanding. I'll need to clarify, but given the instruction, I'll proceed with Objective-C. Wait, but kernel programming in Objective-C is unusual. Maybe they meant a user-level event tap or something using IOKit framework, which is in C. Hmm. This part might be tricky. IOKit drivers are in C++, but the user says Objective-C. Maybe a Cocoa application that intercepts keyboard events? Like using NSEvent addGlobalMonitorForEventsMatchingMask. But that's for applications, not drivers. The user might have mixed up kernel vs user space. For a kernel driver, I'll have to use C or C++ with IOKit. But since the user insists on Objective-C for Mac, perhaps a mistake. I'll proceed with a hypothetical Objective-C driver, but note the discrepancy.
  For Linux, again a kernel module in C. Similar to Android, since Android is based on Linux. The code would involve registering an input device, handling interrupts (maybe from a hardware port), and sending events. The structure would be like writing a basic char driver or input subsystem driver. But handling actual hardware might require access to ports or using APIs like request_irq for interrupts. Since we're simulating, maybe a simple module that creates a device file and allows writing key events to it.
  For Windows, the user wants C++. Windows drivers are typically written using the Windows Driver Framework (WDF) or the older WDM. The code would involve creating a KMDF (Kernel-Mode Driver Framework) driver. The driver would handle IRPs (I/O Request Packets), create a device object, and interact with the HID (Human Interface Device) class. The driver would need to handle IOCTLs or read/write requests to pass key events. In C++, the code would set up a driver entry, device initialization, and maybe a queue for handling reads. But implementing a full HID driver is complex. Maybe a simpler example that creates a device and allows user-mode communication.
  Wait, but each of these examples would be very basic, as writing full drivers is complex. The user might be looking for skeleton code that outlines the structure. Also, handling actual hardware access is OS and hardware-specific. For example, in Linux, inb/outb for port access, but these are x86-specific and might require permissions. Alternatively, using a virtual device or uinput for Linux/Android.
  Let me outline each:
  Android (C): Since Android uses the Linux kernel, the driver would be a kernel module using the input subsystem. Using functions like input_allocate_device, input_register_device, and then sending events with input_report_key, input_sync. The module would need to handle initialization and cleanup.
  Mac (Objective-C): This is confusing. Maybe a user-space daemon using IOKit in C. Alternatively, using a Cocoa app with event taps. For example, using NSEvent masks to monitor global events. But that's not a driver. If the user insists on Objective-C, perhaps a command-line tool using IOKit framework, but IOKit is C-based. Maybe mix Objective-C and C. But this is getting complicated. Perhaps a basic IOKit driver in C, but the user asked for Objective-C. Maybe a mistake, but proceed with a note.
  Linux (C): Similar to Android, a kernel module using input subsystem. Register an input device, send key events. Maybe using a timer to simulate periodic key presses or handling interrupts.
  Windows (C++): Using WDF to create a KMDF driver. Implement driver entry, device creation, and a queue for handling IO requests. The driver could expose a device that user-mode apps can communicate with to send key events.
  But all of these are very simplified. Real drivers handle hardware specifics, which vary widely. Also, installing kernel drivers requires signing and administrative privileges, which is beyond the code.
  Now, considering the example code:
  For Android/Linux: The code would look similar. Maybe in Android's case, using uinput (user-level input) if in userspace, but as a kernel driver, it's similar to Linux. The example provided in the answer uses a kernel module with input_allocate_device etc.
  Mac: If using a kext, which is deprecated in macOS now, but for the sake of example, a simple IOKit driver in C. But the user asked for Objective-C. Maybe they want a user-space program? Using IOKit in Objective-C? For example, finding HID devices and interacting with them. But that's not a driver. This part is unclear.
  Windows: WDF driver in C++. The code would have DRIVER_INITIALIZE DriverEntry, create a device, set up IO queues. Then handle read/write requests to simulate input. But to actually inject keystrokes, the driver would need to interact with the HID stack, which is more involved.
  So, the answer would provide skeleton code for each, noting that they are simplified and that real drivers require more handling, hardware specifics, and proper setup.
  Potential issues to note: Deprecated frameworks (like kexts in macOS), the complexity of driver signing, administrative access, and hardware differences. Also, security implications of writing kernel drivers.
  Need to include warnings that this is simplified and not production-ready, and that driver development requires in-depth knowledge of the OS and hardware.
  Creating keyboard drivers for different operating systems involves low-level programming and interaction with hardware or system frameworks. Below are simplified examples for each platform. Note that these are basic templates and not production-ready solutions. Real drivers require handling hardware specifics, security, and system integration.

---

### 1. **Android (C) – Linux Kernel Input Subsystem** Android uses the Linux kernel, so a keyboard driver can be a kernel module using the input subsystem.

```c
#include <linux/module.h>
#include <linux/input.h>
#include <linux/init.h>

static struct input_dev *keyboard_dev;

static int __init keyboard_init(void) {
    // Allocate input device
    keyboard_dev = input_allocate_device();
    if (!keyboard_dev) return -ENOMEM;

    // Set up device properties
    keyboard_dev->name = "Simple Keyboard";
    keyboard_dev->evbit[0] = BIT_MASK(EV_KEY);
    keyboard_dev->keybit[BIT_WORD(KEY_A)] = BIT_MASK(KEY_A);

    // Register the device
    if (input_register_device(keyboard_dev)) {
        input_free_device(keyboard_dev);
        return -ENODEV;
    }

    // Simulate pressing 'A'
    input_report_key(keyboard_dev, KEY_A, 1);
    input_sync(keyboard_dev);
    return 0;
}

static void __exit keyboard_exit(void) {
    input_unregister_device(keyboard_dev);
    input_free_device(keyboard_dev);
}

module_init(keyboard_init);
module_exit(keyboard_exit);

MODULE_LICENSE("GPL");
```

---

### 2. **macOS (Objective-C) – IOKit HID Driver (C)** **Note:** macOS kernel extensions (kexts) are deprecated. Here's a minimal IOKit driver in **C** (Objective-C isn't used in kernel space):

```c
#include <IOKit/IOLib.h>
#include <IOKit/IOService.h>

class SimpleKeyboardDriver : public IOService {
    OSDeclareDefaultStructors(SimpleKeyboardDriver);

public:
    virtual bool init(OSDictionary *dict) override {
        if (!IOService::init(dict)) return false;
        return true;
    }

    virtual void free() override {
        IOService::free();
    }
};

OSDefineMetaClassAndStructors(SimpleKeyboardDriver, IOService);
```

**Important:** Modern macOS prefers user-space HID drivers using frameworks like `IOKit` and `CoreFoundation`.

---

### 3. **Linux (C) – Kernel Input Module**
Similar to Android, but may handle hardware interrupts:

```c
#include <linux/module.h>
#include <linux/input.h>
#include <linux/interrupt.h>

static struct input_dev *linux_keyboard_dev;

static irqreturn_t keyboard_interrupt(int irq, void *dev_id) {
    input_report_key(linux_keyboard_dev, KEY_SPACE, 1);
    input_sync(linux_keyboard_dev);
    return IRQ_HANDLED;
}

static int __init linux_keyboard_init(void) {
    linux_keyboard_dev = input_allocate_device();
    // ... (similar setup to Android example)
    return 0;
}

static void __exit linux_keyboard_exit(void) {
    input_unregister_device(linux_keyboard_dev);
}

module_init(linux_keyboard_init);
module_exit(linux_keyboard_exit);
MODULE_LICENSE("GPL");
```

---

### 4. **Windows (C++) – WDF KMDF Driver**
A basic keyboard driver using the Windows Driver Framework:

```cpp
#include <ntddk.h>
#include <wdf.h>

DRIVER_INITIALIZE DriverEntry;
EVT_WDF_DRIVER_DEVICE_ADD SimpleKeyboardEvtDeviceAdd;

NTSTATUS DriverEntry(PDRIVER_OBJECT DriverObject, PUNICODE_STRING RegistryPath) {
    WDF_DRIVER_CONFIG config;
    WDF_DRIVER_CONFIG_INIT(&config, SimpleKeyboardEvtDeviceAdd);
    return WdfDriverCreate(DriverObject, RegistryPath, WDF_NO_OBJECT_ATTRIBUTES, &config, WDF_NO_HANDLE);
}

NTSTATUS SimpleKeyboardEvtDeviceAdd(WDFDRIVER Driver, PWDFDEVICE_INIT DeviceInit) {
    WDFDEVICE device;
    NTSTATUS status = WdfDeviceCreate(&DeviceInit, WDF_NO_OBJECT_ATTRIBUTES, &device);
    if (!NT_SUCCESS(status)) return status;

    // Set up HID or keyboard-specific functionality here
    return status;
}
```

---

### Key Notes:
1. **Complexity**: Real drivers handle hardware communication (e.g., USB, PS/2), interrupts, and system security.
2. **Signing**: Modern OSes require drivers to be signed (e.g., Windows HLK, macOS notarization).
3. **Deprecations**: macOS kexts are deprecated; use user-space HID drivers instead.
4. **Testing**: Use virtual machines or test hardware to avoid system instability.

Always refer to official OS documentation for up-to-date practices.